### PR TITLE
Added manage.py for executing flask utility commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ python:
 
 branches:
     only:
-        - master
+        - gh-pages
+        - /.*/
 
 cache:
     apt: true

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,33 @@
+# manage.py
+
+import flask
+from flask_script import Manager
+
+from app import app
+
+manager = Manager(app)
+
+
+@manager.command
+def list_routes():
+    import urllib.request
+    import urllib.parse
+    import urllib.error
+    output = []
+    for rule in app.url_map.iter_rules():
+
+        options = {}
+        for arg in rule.arguments:
+            options[arg] = "[{0}]".format(arg)
+
+        methods = ','.join(rule.methods)
+        url = flask.url_for(rule.endpoint, **options)
+        line = urllib.parse.unquote(
+            "{:50s} {:20s} {}".format(rule.endpoint, methods, url))
+        output.append(line)
+
+    for line in sorted(output):
+        print(line)
+
+if __name__ == "__main__":
+    manager.run()

--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,6 @@ from app import app
 
 manager = Manager(app)
 
-
 @manager.command
 def list_routes():
     import urllib.request

--- a/models.py
+++ b/models.py
@@ -44,8 +44,10 @@ if os.environ.get('DB_PASSWORD', ''):
                                     host='catappdatabase.cjlis1fysyzx.us-west-1.rds.amazonaws.com',
                                     port=5432,
                                     database='catappdatabase')
+    PRODUCTION = True
 else:
     url = sqlalchemy.engine.url.URL('sqlite', database='./test_database.db')
+    PRODUCTION = False
 
 
 engine = sqlalchemy.create_engine(
@@ -69,7 +71,7 @@ Base.query = db_session.query_property()
 
 class Catapp(Base):
     __tablename__ = 'catapp'
-    __table_args__ = ({'schema': 'public'})
+    __table_args__ = ({'schema': 'public' if PRODUCTION else 'main'})
     id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
     #rowid = sqlalchemy.sqlalchemy.Column(sqlalchemy.Integer)
     chemical_composition = sqlalchemy.Column(sqlalchemy.String, )
@@ -155,14 +157,14 @@ class Catapp(Base):
 
 class Information(Base):
     __tablename__ = 'information'
-    __table_args__ = ({'schema': 'public'})
+    __table_args__ = ({'schema': 'public' if PRODUCTION else 'main'})
     name = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
     value = sqlalchemy.Column(sqlalchemy.String, )
 
 
 class System(Base):
     __tablename__ = 'systems'
-    __table_args__ = ({'schema': 'public'})
+    __table_args__ = ({'schema': 'public' if PRODUCTION else 'main'})
     id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
     #rowid = sqlalchemy.Column(sqlalchemy.Integer, )
     unique_id = sqlalchemy.Column(sqlalchemy.String, )
@@ -376,9 +378,9 @@ class System(Base):
 
 class Species(Base):
     __tablename__ = 'species'
-    __table_args__ = ({'schema': 'public'})
+    __table_args__ = ({'schema': 'public' if PRODUCTION else 'main'})
     id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey(
-        'public.systems.id'), primary_key=True)
+        'public.systems.id' if PRODUCTION else 'main.systems.id'), primary_key=True)
     #rowid = sqlalchemy.Column(sqlalchemy.Integer, )
     Z = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True,)
     n = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True,)
@@ -386,18 +388,18 @@ class Species(Base):
 
 class Key(Base):
     __tablename__ = 'keys'
-    __table_args__ = ({'schema': 'public'})
+    __table_args__ = ({'schema': 'public' if PRODUCTION else 'main'})
     id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey(
-        'public.systems.id'), primary_key=True)
+        'public.systems.id' if PRODUCTION else 'main.systems.id'), primary_key=True)
     #rowid = sqlalchemy.Column(sqlalchemy.Integer, )
     key = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
 
 
 class NumberKeyValue(Base):
     __tablename__ = 'number_key_values'
-    __table_args__ = ({'schema': 'public'})
+    __table_args__ = ({'schema': 'public' if PRODUCTION else 'main'})
     id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey(
-        'public.systems.id'), primary_key=True)
+        'public.systems.id' if PRODUCTION else 'main.systems.id'), primary_key=True)
     #rowid = sqlalchemy.Column(sqlalchemy.Integer, )
     key = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
     value = sqlalchemy.Column(sqlalchemy.Float,)
@@ -405,9 +407,9 @@ class NumberKeyValue(Base):
 
 class TextKeyValue(Base):
     __tablename__ = 'text_key_values'
-    __table_args__ = ({'schema': 'public'})
+    __table_args__ = ({'schema': 'public' if PRODUCTION else 'main'})
     id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey(
-        'public.systems.id'), primary_key=True)
+        'public.systems.id' if PRODUCTION else 'main.systems.id'), primary_key=True)
     #rowid = sqlalchemy.Column(sqlalchemy.Integer, )
     key = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
     value = sqlalchemy.Column(sqlalchemy.String,)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cycler==0.10.0
 Flask==0.12.2
 Flask-Cors==3.0.3
 Flask-GraphQL==1.4.1
+Flask-Script==2.0.6
 graphene==2.0.dev20170802065539
 graphene-sqlalchemy==2.0.dev2017083101
 graphql-core==2.0.dev20171009101843


### PR DESCRIPTION
`manage.py` is a placeholder for running utility commands around the flask app. Run
    `python manage.py`
to list possible commands. The only useful command right now is
    `python manage.py list_routes`
that will show all routes known to the router. Yay!