### PR TITLE
Feature sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mhoffman/CatAppBackend.svg?branch=feature_NRR)](https://travis-ci.org/mhoffman/CatAppBackend)
+[![Build Status](https://travis-ci.org/mhoffman/CatAppBackend.svg?branch=feature_sort)](https://travis-ci.org/mhoffman/CatAppBackend)
 
 ## Flask GraphQL ASE DB Demo
 

--- a/api.py
+++ b/api.py
@@ -374,7 +374,7 @@ class Reaction(CustomSQLAlchemyObjectType):
 
 class FilteringConnectionField(graphene_sqlalchemy.SQLAlchemyConnectionField):
     RELAY_ARGS = ['first', 'last', 'before', 'after']
-    SPECIAL_ARGS = ['distinct', 'op', 'jsonkey']
+    SPECIAL_ARGS = ['distinct', 'op', 'jsonkey', 'order']
 
     @classmethod
     def get_query(cls, model, info, **args):
@@ -430,6 +430,15 @@ class FilteringConnectionField(graphene_sqlalchemy.SQLAlchemyConnectionField):
                     op = value
             elif field == 'jsonkey':
                 jsonkey_input = value
+            elif field == 'order':
+                ascending = not value.startswith('-')
+                column_name = value if not value.startswith('-') else value[1:]
+                column = getattr(model, convert(column_name), None)
+
+                if ascending:
+                    query = query.order_by(column)
+                else:
+                    query = query.order_by(column.desc())
 
         for field, value in args.items():
             if field not in (cls.RELAY_ARGS + cls.SPECIAL_ARGS):
@@ -558,6 +567,7 @@ def get_filter_fields(model):
     filter_fields['op'] = graphene.String()
     filter_fields['search'] = graphene.String()
     filter_fields['jsonkey'] = graphene.String()
+    filter_fields['order'] = graphene.String()
 
     return filter_fields
 

--- a/tests/test_api_unittest.py
+++ b/tests/test_api_unittest.py
@@ -121,6 +121,17 @@ class ReactionBackendTestCase(unittest.TestCase):
         assert results_reactions[0]['dftCode'] == 'Quantum ESPRESSSO', results_reactions[0]['dftCode']
         assert results_reactions[0]['dftFunctional'] == 'RPBE', results_reactions[0]['dftFunctional']
 
+    def test_order_key(self):
+        query ='{systems(last: 1, order: "energy") {edges {node { Formula energy} } }}'
+        rv_data = self.get_data(query)
+        assert rv_data['data']['systems']['edges'][0]['node']['Formula'] == 'H2', rv_data
+
+    def test_order_key_descending(self):
+        query ='{systems(last: 1, order: "-energy") {edges {node { Formula energy} } }}'
+        rv_data = self.get_data(query)
+        assert rv_data['data']['systems']['edges'][0]['node']['Formula'] == 'Cu36Zn3', rv_data
+
+
     #def test_graphql5(self):
         ## TEST if we can query by DOI
         #query = '{publications(doi: "10.1021/acs.jpcc.6b03375") { edges { node { title systems { Formula } } } }}'

--- a/tests/test_api_unittest.py
+++ b/tests/test_api_unittest.py
@@ -124,13 +124,12 @@ class ReactionBackendTestCase(unittest.TestCase):
     def test_order_key(self):
         query ='{systems(last: 1, order: "energy") {edges {node { Formula energy} } }}'
         rv_data = self.get_data(query)
-        assert False, rv_data
+        assert rv_data['data']['systems']['edges'][0]['node']['Formula'] == 'H2', rv_data
 
     def test_order_key_descending(self):
         query ='{systems(last: 1, order: "-energy") {edges {node { Formula energy} } }}'
         rv_data = self.get_data(query)
-        assert False, rv_data
-
+        assert rv_data['data']['systems']['edges'][0]['node']['Formula'] == 'Cu36Zn3', rv_data
 
 
     #def test_graphql5(self):

--- a/tests/test_api_unittest.py
+++ b/tests/test_api_unittest.py
@@ -121,6 +121,18 @@ class ReactionBackendTestCase(unittest.TestCase):
         assert results_reactions[0]['dftCode'] == 'Quantum ESPRESSSO', results_reactions[0]['dftCode']
         assert results_reactions[0]['dftFunctional'] == 'RPBE', results_reactions[0]['dftFunctional']
 
+    def test_order_key(self):
+        query ='{systems(last: 1, order: "energy") {edges {node { Formula energy} } }}'
+        rv_data = self.get_data(query)
+        assert False, rv_data
+
+    def test_order_key_descending(self):
+        query ='{systems(last: 1, order: "-energy") {edges {node { Formula energy} } }}'
+        rv_data = self.get_data(query)
+        assert False, rv_data
+
+
+
     #def test_graphql5(self):
         ## TEST if we can query by DOI
         #query = '{publications(doi: "10.1021/acs.jpcc.6b03375") { edges { node { title systems { Formula } } } }}'


### PR DESCRIPTION
Added sort for graphql queries. Allows for queries like 

```
{systems(first: 10, order:"-energy") {
      edges {
        node {
          id
          energy
          Formula
          InputFile(format:"vasp")
        }
      }
    }}

```

Key needs to be native column name, i.e. not hybrid or otherwise calculated property. Sorting is ignored when column name does not exist. By default sort order is ascending. Prefixing with '-' leads to descending order
    
Added unit test for sorting
