### PR TITLE
Feature timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/mhoffman/CatAppBackend.svg?branch=feature_unit_tests)](https://travis-ci.org/mhoffman/CatAppBackend)
-[![Coverage Status](https://coveralls.io/repos/github/mhoffman/CatAppBackend/badge.svg?branch=feature_unit_tests)](https://coveralls.io/github/mhoffman/CatAppBackend?branch=feature_unit_tests)
+[![Build Status](https://travis-ci.org/mhoffman/CatAppBackend.svg?branch=feature_timestamp)](https://travis-ci.org/mhoffman/CatAppBackend)
+[![Coverage Status](https://coveralls.io/repos/github/mhoffman/CatAppBackend/badge.svg?branch=feature_timestamp)](https://coveralls.io/github/mhoffman/CatAppBackend?branch=feature_timestamp)
 
 ## Flask GraphQL ASE DB Demo
 

--- a/models.py
+++ b/models.py
@@ -1,5 +1,6 @@
 # global imports
 import os
+import datetime
 import sqlalchemy
 import sqlalchemy.types
 import sqlalchemy.ext.declarative
@@ -23,6 +24,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 # more unstable imports
 import ase.atoms
 import ase.db.sqlite
+import ase.db.core
 import ase.io
 
 
@@ -343,6 +345,24 @@ class System(Base):
     @hybrid_property
     def _charges(self):
         return (ase.db.sqlite.deblob(self.charges).tolist())
+
+    @hybrid_property
+    def _ctime(self):
+        return (
+                datetime.datetime(2000, 1, 1, 0, 0)
+                + datetime.timedelta(
+                    seconds=int(round(self.ctime * ase.db.core.seconds['y'], 0))
+                    )
+                ).strftime('%c')
+
+    @hybrid_property
+    def _mtime(self):
+        return (
+                datetime.datetime(2000, 1, 1, 0, 0)
+                + datetime.timedelta(
+                    seconds=int(round(self.mtime * ase.db.core.seconds['y'], 0))
+                    )
+                ).strftime('%c')
 
 
     ###################################

--- a/tests/test_api_unittest.py
+++ b/tests/test_api_unittest.py
@@ -313,5 +313,14 @@ class ReactionBackendTestCase(unittest.TestCase):
         rv_data = self.get_data('{reactions(first: 1, reactants:"~Ogas", distinct: false) { totalCount edges { node { id Equation } } }}')
         assert rv_data['data']['reactions']['edges'][0]['node']['Equation'] == 'H2O(g) -> hfH2(g) + OH*', rv_data
 
+    def test_timestamp_mtime(self):
+        rv_data = self.get_data('{systems(first:10, order:"mtime") { edges { node { id Mtime } } }}')
+        assert False, rv_data
+
+    def test_timestamp_ctime(self):
+        rv_data = self.get_data('{systems(first:10, order:"ctime") { edges { node { id Ctime } } }}')
+        assert False, rv_data
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_api_unittest.py
+++ b/tests/test_api_unittest.py
@@ -315,11 +315,11 @@ class ReactionBackendTestCase(unittest.TestCase):
 
     def test_timestamp_mtime(self):
         rv_data = self.get_data('{systems(first:10, order:"mtime") { edges { node { id Mtime } } }}')
-        assert False, rv_data
+        assert rv_data['data']['systems']['edges'][0]['node']['Mtime'] == 'Mon Feb 12 23:02:48 2018', rv_data
 
     def test_timestamp_ctime(self):
         rv_data = self.get_data('{systems(first:10, order:"ctime") { edges { node { id Ctime } } }}')
-        assert False, rv_data
+        assert rv_data['data']['systems']['edges'][0]['node']['Ctime'] == 'Fri Feb  2 07:09:45 2018', rv_data
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added `Mtime` and `Ctime` fields for a more human readable version of `mtime` and `ctime`.  Demo
```
{systems(first: 1) {
  edges {
    node {
      Formula
      energy
      mtime
      Mtime
      ctime
      Ctime
    }
  }
}}
```
will return

```
{
  "data": {
    "systems": {
      "edges": [
        {
          "node": {
            "Formula": "NO",
            "energy": -737.570235164777,
            "mtime": 18.1189877586222,
            "Mtime": "Mon Feb 12 23:02:48 2018",
            "ctime": 18.1185034728591,
            "Ctime": "Mon Feb 12 18:48:05 2018"
          }
        }
      ]
    }
  }
}
```

The human readable date string `s` can be parsed, e.g. using python
`datetime.datetime.strptime(s, '%c')`