### PR TITLE
Hotfix page info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/mhoffman/CatAppBackend.svg?branch=feature_unit_tests)](https://travis-ci.org/mhoffman/CatAppBackend)
-[![Coverage Status](https://coveralls.io/repos/github/mhoffman/CatAppBackend/badge.svg?branch=feature_unit_tests)](https://coveralls.io/github/mhoffman/CatAppBackend?branch=feature_unit_tests)
+[![Build Status](https://travis-ci.org/mhoffman/CatAppBackend.svg?branch=hotfix_page_info)](https://travis-ci.org/mhoffman/CatAppBackend)
+[![Coverage Status](https://coveralls.io/repos/github/mhoffman/CatAppBackend/badge.svg?branch=hotfix_page_info)](https://coveralls.io/github/mhoffman/CatAppBackend?branch=hotfix_page_info)
 
 ## Flask GraphQL ASE DB Demo
 

--- a/api.py
+++ b/api.py
@@ -389,7 +389,7 @@ class FilteringConnectionField(graphene_sqlalchemy.SQLAlchemyConnectionField):
                        '=',  '>',  '<',  '>=', '<=', '!=']
 
         cont_fields = ['edges', 'node']
-        skip_fields = ['totalCount']
+        skip_fields = ['totalCount', 'pageInfo']
         fields = info.field_asts# [0].selection_set.selections
         load_fields = {}
         field_names = []

--- a/tests/test_api_unittest.py
+++ b/tests/test_api_unittest.py
@@ -313,5 +313,9 @@ class ReactionBackendTestCase(unittest.TestCase):
         rv_data = self.get_data('{reactions(first: 1, reactants:"~Ogas", distinct: false) { totalCount edges { node { id Equation } } }}')
         assert rv_data['data']['reactions']['edges'][0]['node']['Equation'] == 'H2O(g) -> hfH2(g) + OH*', rv_data
 
+    def test_page_info(self):
+        rv_data = self.get_data('{systems(first: 2, after:"") { totalCount pageInfo { hasNextPage hasPreviousPage startCursor endCursor } edges { node { Formula energy mtime } } }}')
+        assert False, rv_data
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_api_unittest.py
+++ b/tests/test_api_unittest.py
@@ -315,7 +315,7 @@ class ReactionBackendTestCase(unittest.TestCase):
 
     def test_page_info(self):
         rv_data = self.get_data('{systems(first: 2, after:"") { totalCount pageInfo { hasNextPage hasPreviousPage startCursor endCursor } edges { node { Formula energy mtime } } }}')
-        assert False, rv_data
+        assert rv_data['data']['systems']['pageInfo']['startCursor'] == 'YXJyYXljb25uZWN0aW9uOjA=', rv_data
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Page info works again and has a regression test on it. Allows to page through long results. Next batch of results can be obtained using `after` keyword with `endCursor` from current result. Demo: 
```
{systems(first:10, after:"YXJyYXljb25uZWN0aW9uOjk=") {
  pageInfo {
    hasNextPage
    hasPreviousPage
    startCursor
    endCursor
  }
  edges {
    node {
      id
    }
  }
}}


```
Will return: 
```
{
  "data": {
    "systems": {
      "pageInfo": {
        "hasNextPage": true,
        "hasPreviousPage": false,
        "startCursor": "YXJyYXljb25uZWN0aW9uOjIw",
        "endCursor": "YXJyYXljb25uZWN0aW9uOjI5"
      },
      "edges": [
        {
          "node": {
            "id": "U3lzdGVtOjIw"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjIx"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjIy"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjI0"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjI1"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjI2"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjI3"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjI4"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjI5"
          }
        },
        {
          "node": {
            "id": "U3lzdGVtOjMw"
          }
        }
      ]
    }
  }
}

```
